### PR TITLE
Fix the include config.h problem

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@ endif
 # Build the entire system for the first time
 
 world:
-	cd config; $(MAKE) defs.h; sh autoconf $(CC)
+	cd config; $(MAKE) all
 	cd runtime; $(MAKE) all
 	cp runtime/camlrunm$(EXE) .
 	cd mosmlyac; $(MAKE) all
@@ -73,7 +73,6 @@ install:
 	cd compiler; $(MAKE) install
 	cd toolssrc; $(MAKE) install
 	cd lex; $(MAKE) install
-	(cd $(INCDIR)/..; rm -fr config; ln -s include config)
 	cd doc; $(MAKE) install
 	$(MAKE) basisdynlib_install
 

--- a/src/config/Makefile
+++ b/src/config/Makefile
@@ -1,17 +1,19 @@
 include ../Makefile.inc
 
-all: defs.h
-	@echo "Run 'sh autoconf' or 'sh autoconf gcc' or ..."
+all: defs.h runtime
 
 defs.h:
 	@echo "#define VERSION $(VERSION)" > defs.h
 	@echo "#define VERSION_S \"$(VERSION)\"" >> defs.h
 	@echo "#define DYNLIBSUPPORT $(DYNLIBSUPPORT)" >> defs.h 
 	@echo "#define DYNLIBSUPPORT_S \"$(DYNLIBSUPPORT)\"" >> defs.h 
+	sh autoconf $(CC)
 
+.PHONY: runtime
+runtime:
+	$(INSTALL_PROGRAM) m.h s.h ../runtime
 
 install:
-	$(INSTALL_PROGRAM) m.h s.h $(INCDIR)
 
 clean scratch:
 	rm -f m.h s.h defs.h

--- a/src/runtime/.gitignore
+++ b/src/runtime/.gitignore
@@ -3,3 +3,5 @@ camlrunm
 jumptbl.h
 primitives
 prims.c
+m.h
+s.h

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -42,6 +42,7 @@ clean:
 	rm -f camlrunm$(EXE) camlrunmd$(EXE) *.o *.a
 	rm -f primitives prims.c opnames.h jumptbl.h
 	rm -f .debugobj/*.o
+	rm -f m.h s.h
 
 install:
 	${INSTALL_PROGRAM} camlrunm$(EXE) $(BINDIR)

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -1,27 +1,8 @@
 #ifndef _config_
 #define _config_
 
-
-#if defined(__MWERKS__) || defined(THINK_C)
 #include "m.h"
 #include "s.h"
-#else
-#ifdef macintosh
-#include ":::config:m.h"
-#include ":::config:s.h"
-#else
-#if defined(msdos)
-#include "../config.dos/m.h"
-#include "../config.dos/s.h"
-#elif defined(WIN32)
-#include "../config.w32/m.h"
-#include "../config.w32/s.h"
-#else
-#include "../config/m.h"
-#include "../config/s.h"
-#endif
-#endif
-#endif
 
 #ifdef WIN32
 


### PR DESCRIPTION
We copy m.h and s.h to the runtime directory immediately after generating
them, instead of waiting for the installation stage. That way we both get
of the ugly config symbolic link, and we avoid the ugly includes in config.h
