### PR TITLE
Add -fno-stack-protector to DYNLIBCFLAGS

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -48,7 +48,7 @@ endif
 
 ADDRUNLIBS=-ldl
 ADDRUNCFLAGS=-fPIC
-ADDDYNLIBCFLAGS=-fPIC
+ADDDYNLIBCFLAGS=-fPIC -fno-stack-protector
 
 
 # For Linux, use:


### PR DESCRIPTION
Should fix #14.

This fixes the "undefined reference to __stack_chk_fail_local'" when building
dynlibs (specifically when compiling msocket) on x86.

If -fPIC is specified (which is needed to compile shared libraries, such
as the dynlibs on x64) it seems like the -fno-stack-protector flag is
necessary for the dynlibs to compile on x86.

More info:
https://github.com/dailab/libsml/issues/3#ref-commit-b9229cb
http://ubuntuforums.org/showthread.php?t=352642
http://stackoverflow.com/questions/10712972/what-is-the-use-of-fno-stack-protector
