### PR TITLE
Add configuration file for Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# Configuration file for Travis CI (http://travis-ci.org)
+language: c
+compiler: gcc
+
+env:
+    - TARGET=linux
+    - TARGET=cross_w32
+
+before_install:
+    - sudo apt-get update -qq
+install:
+    - ./src/tools/travis install
+script:
+    - ./src/tools/travis build
+after_script:
+    - ./src/tools/travis test
+
+
+branches:
+    only:
+        - master
+
+notifications:
+    email:
+        on_success: change
+        on_failure: always

--- a/src/tools/travis
+++ b/src/tools/travis
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Script for handling execution of builds with Travis CI (travis-ci.org).
+
+# show information about system used for building
+uname -a
+
+case "$1" in
+    "install")
+        case "$TARGET" in
+            "linux") sudo apt-get install -y libgmp-dev ;;
+            "cross_w32") which i586-mingw32msvc-gcc || sudo apt-get -f -y install gcc-mingw32 ;;
+        esac
+    ;;
+    "build")
+        case "$TARGET" in
+            "linux") cd src && make world && sudo make install ;;
+            "cross_w32")
+                INSTALLDIR=/tmp/mosml_install
+                cd src && make cross_w32 PREFIX=$INSTALLDIR ;;
+        esac
+    ;;
+    "test")
+    ;;
+esac


### PR DESCRIPTION
This patch adds a configuration file for use with [Travis CI](http://travis-ci.org), a free online continuous integration system. The system watches monitors new commits and pull requests, ensuring that the system still builds with them applied. 

In order for this patch to work, Travis first needs to be activated on the repository from their website. To see the interface, [click here](https://travis-ci.org/Eckankar/mosml) to see how the system looks on my fork.

As the configuration is right now, the system is set to compile on the linux 64-bit and cross_w32 targets. No tests are currently run, but I'm thinking it shouldn't take much work to rework the tests in `src/test/` to be usable in this context. (Apart from needing to update them to work on 64 bit.) Still, even without tests I figure that verifying that the system builds is a positive thing.

The configuration has Travis send e-mail notifications to committer if the build is broken/fixed. It might be useful to expand on this as desired. ([Docs](http://docs.travis-ci.com/user/notifications/#Email-notifications))
