### PR TITLE
Generate shebang header at make world stage.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,3 +2,4 @@
 camlrunm
 config/m.h
 config/s.h
+launch/header

--- a/src/launch/Makefile
+++ b/src/launch/Makefile
@@ -3,12 +3,13 @@
 
 include ../Makefile.inc
 
-all: mosml mosmlc mosmllex camlexec testprog 
-
-# header cannot be generated until camlrunm is installed in $(BINDIR)...
+all: header mosml mosmlc mosmllex camlexec testprog
 
 install:
-	echo "#!$(BINDIR)/camlrunm" > $(DESTDIR)$(LIBDIR)/header;
+	# header cannot be used until camlrunm is installed in $(BINDIR)...
+	# but we have to pregenerate it with directories of BUILD phase, since
+	# while packaging (RPM) "make install" runs with fake-root.
+	cp header $(DESTDIR)$(LIBDIR)/header;
 	for script in mosml mosmlc mosmllex; do \
 	  ${INSTALL_SCRIPT} $$script $(DESTDIR)$(BINDIR)/$$script; \
 	  chmod a+x $(DESTDIR)$(BINDIR)/$$script; \
@@ -30,6 +31,8 @@ old_install:
 	  chmod a+x $(BINDIR)/$$script; \
 	done
 
+header:
+	echo "#!$(BINDIR)/camlrunm" > header
 
 mosml: mosml.tpl
 	sed -e "s|LIBDIR|$(LIBDIR)|" -e "s|BINDIR|$(BINDIR)|" mosml.tpl > mosml


### PR DESCRIPTION
Ken,

while making mosml RPM package for my distribution I met a problem with incorrect shebang line in binaries, that were created with installed MosML. 

Packages are built under regular user, so, one can not write to system directories. The packaging process involves 2 stages - build and install. On build stage you can use any directory as PREFIX, while on install stage PREFIX is provided by RPM build system, so it is a fake root, smth like
 `/home/const/tmp/mosml-buildroot`

Therefore shebang header should be generated at build stage, but not at install stage. And overall, no path variable should be defined at install stage.

This header does not affect bootstrap compilers, because these binaries do not include shebang header and should be run with direct call to camlrunm. You can check it by (as I did):

1.  `make world`
2.  go to `src/compiler` directory, `make clean`, `make`, `make promote`
3.  look at bootstrap binaries in src directory - they do not contain shebang and header is already generated.