### PR TITLE
Fixed obsolete flag.

### DIFF
--- a/src/runtime/sys.c
+++ b/src/runtime/sys.c
@@ -278,7 +278,7 @@ void mysignal(int signum, sighandler_return_type (*handler)(int)) {
   sigemptyset(&emptyset);
   sigact.sa_handler  = handler;
   sigact.sa_mask     = emptyset;
-  sigact.sa_flags    = SA_NOMASK;
+  sigact.sa_flags    = SA_NODEFER;
   sigaction(signum, &sigact, 0); 
 #else
   signal(signum, handler);


### PR DESCRIPTION
From sigaction(2):

	SA_NODEFER
		Do not prevent the signal from being received from within
		its own signal handler.  This flag is meaningful only when
		establishing a signal handler.  SA_NOMASK is an obsolete,
		nonstandard synonym for this flag.