### PR TITLE
Add some missing headers

### DIFF
--- a/src/dynlibs/mgd/mgd.c
+++ b/src/dynlibs/mgd/mgd.c
@@ -4,7 +4,7 @@
  */
 
 #include <gd.h>			/* For gd                        */
-#include <gdfontt.h>		/* For gd font description files */
+#include <gdfontt.h>	/* For gd font description files */
 #include <gdfonts.h>
 #include <gdfontmb.h>
 #include <gdfontl.h>
@@ -22,7 +22,9 @@
 /* Moscow ML specific includes: */
 
 #include <alloc.h>		/* For alloc_tuple, ...      */
-#include <mlvalues.h>		/* For Val_unit, Long_val, String_val, ... */
+#include <mlvalues.h>	/* For Val_unit, Long_val, String_val, ... */
+#include <fail.h>		/* for failwith */
+#include <memory.h>		/* for modify */
 
 /* Representation of images.  
 

--- a/src/dynlibs/mmysql/mmysql.c
+++ b/src/dynlibs/mmysql/mmysql.c
@@ -3,11 +3,11 @@
    sestoft@dina.kvl.dk 1999-08-07, 2000-05-30, 2002-07-25 */
 
 #include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #ifdef WIN32
 #include <windows.h>
-#include <stdio.h>
-#include <string.h>
 #endif
 
 /* Access to the camlrunm/Moscow ML runtime data representation: */


### PR DESCRIPTION
This is to partly address this failure: https://github.com/kfl/mosml/issues/71
It seems that these headers were simply forgotten here, since other files add them when related functions are used.