### PR TITLE
Utilize variables for the build in more places

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,11 @@
 # Unix Makefile for Moscow ML
 
-# To build the Moscow ML system on a new machine for the first time, 
+# To build the Moscow ML system on a new machine for the first time,
 #	(1) edit PREFIX etc. in file Makefile.inc
 #	(2) execute `make world'
+#
+# Alternatively,
+# (1) execute `PREFIX=/path/to/prefix make world`
 
 # To install it
 
@@ -100,6 +103,7 @@ install:
 	test -d $(DESTDIR)$(INCDIR) || mkdir -p $(DESTDIR)$(INCDIR)
 	test -d $(DESTDIR)$(DOCDIR) || mkdir -p $(DESTDIR)$(DOCDIR)
 	test -d $(DESTDIR)$(TOOLDIR) || mkdir -p $(DESTDIR)$(TOOLDIR)
+
 	cd runtime; $(MAKE) install
 #	cd config; $(MAKE) install
 	cd launch; $(MAKE) all install
@@ -144,7 +148,7 @@ clean:
 	cd lex; $(MAKE) clean
 	cd test; $(MAKE) clean
 	cd mosmllib/test; $(MAKE) clean
-	cd ../examples; $(MAKE) clean	
+	cd ../examples; $(MAKE) clean
 	cd dynlibs; $(MAKE) clean
 	rm -f camlrunm$(EXE)
 	cd doc; $(MAKE) clean

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -1,7 +1,7 @@
 # Unix configuration Makefile for Moscow ML          -*- mode: makefile -*-
 
 # Where to install stuff
-PREFIX=/usr/local
+PREFIX?=/usr/local
 
 # BINDIR contains true executable files, such as scripts
 # LIBDIR contains bytecode files (such as mosmlcmp and library units), and .dll/.so for dynlibs.
@@ -36,7 +36,6 @@ PERL=perl
 BASELIBS=-lm
 
 # This works with most systems, including MacOS X with XCode installed:
-
 CC=gcc
 # CC=gcc -mmacosx-version-min=10.7 # for building OS X package
 # CC=/usr/sepp/bin/gcc		# Solaris at KVL
@@ -90,10 +89,11 @@ ifeq ($(UNAME_S),Cross_W32)
 endif
 ifeq ($(UNAME_S),OpenBSD)
 	ADDRUNLIBS=
+	CC=cc
 	CPP=cpp -P -traditional -Dunix -Umsdos -Wno-invalid-pp-token
 	STRIP=strip -S
-	LD=gcc -rdynamic -Wl,-rpath,$(LIBDIR)
-	DYNLD=gcc -shared
+	LD=cc -rdynamic -Wl,-rpath,$(LIBDIR)
+	DYNLD=cc -shared
 endif
 
 ifeq ($(UNAME_S),Custom) # Your configuration here

--- a/src/compiler.cminusminus/Makefile
+++ b/src/compiler.cminusminus/Makefile
@@ -53,7 +53,7 @@ T_OBJS= \
     Predef.uo Prim_c.uo Symtable.uo Patch.uo Tr_const.uo \
     Rtvals.uo Load_phr.uo Exec_phr.uo Smltop.uo Maint.uo
 
-all: mosmlcmmc 
+all: mosmlcmmc
 
 dos: mosmlcmp.dos mosmllnk.dos mosmltop.dos
 
@@ -84,14 +84,14 @@ mosmllnk.dos: $(L_OBJS)
 mosmllnk.w32: $(L_OBJS)
 	$(MOSMLL) $(LINKFLAGS) -o mosmllnk.w32 Mainl.uo
 
-Predef.sml : $(CAMLRT)/globals.h 
+Predef.sml : $(CAMLRT)/globals.h
 	$(PERL) $(MOSMLTOOLS)/mksmlpre $(CAMLRT)/globals.h > Predef.sml
 
 Prim_c.sml : $(CAMLRT)/primitives
 	$(PERL) $(MOSMLTOOLS)/mksmlprc $(CAMLRT)/primitives > Prim_c.sml
 
 mosmltop: $(COMP_OBJS) $(T_OBJS)
-	$(MOSMLL) $(LINKFLAGS) -o mosmltop Maint.uo 
+	$(MOSMLL) $(LINKFLAGS) -o mosmltop Maint.uo
 
 mosmltop.dos: $(COMP_OBJS) $(T_OBJS)
 	$(MOSMLLDOS) $(LINKFLAGS) -o mosmltop Maint.uo
@@ -125,8 +125,8 @@ promote:
 	#test -f ../mosmllnk.orig || cp ../mosmllnk ../mosmllnk.orig
 	#test -f ../mosmllex.orig || cp ../mosmllex ../mosmllex.orig
 	#$(MOSMLL) $(LINKFLAGS) -o mosmlcmp $(C_LIBOBJS) $(COMP_OBJS) $(C_OBJS)
-	#$(MOSMLL) $(LINKFLAGS) -o mosmllnk $(L_LIBOBJS) $(L_OBJS) 
-	#$(MOSMLL) $(LINKFLAGS) -o mosmltop $(T_LIBOBJS) $(T_OBJS) 
+	#$(MOSMLL) $(LINKFLAGS) -o mosmllnk $(L_LIBOBJS) $(L_OBJS)
+	#$(MOSMLL) $(LINKFLAGS) -o mosmltop $(T_LIBOBJS) $(T_OBJS)
 	#test -f mosmllnk && cp mosmllnk ../mosmllnk
 	test -f mosmlcmmc && cp mosmlcmmc ../mosmlcmmc
 	#test -f ../lex/mosmllex && cp ../lex/mosmllex ../mosmllex
@@ -146,145 +146,145 @@ depend: Filename.sml Config.sml Opcodes.sml Parser.sml Parser.sig Lexer.sml \
 
 regress:
 	echo "building current lib"
-	cd ../mosmllib; make -s current
+	cd ../mosmllib; $(MAKE) -s current
 	echo "testing current lib"
-	cd ../mosmllib/test; make -s current  || echo "results differ"
+	cd ../mosmllib/test; $(MAKE) -s current  || echo "results differ"
 	echo "testing current test"
-	cd ../test; make -s current || echo "results differ"
+	cd ../test; $(MAKE) -s current || echo "results differ"
 	echo "testing current compiler test"
-	cd test; make -s current || echo "results differ"
+	cd test; $(MAKE) -s current || echo "results differ"
 
 ### DO NOT DELETE THIS LINE
-Wpp.uo: Wpp.ui 
+Wpp.uo: Wpp.ui
 CmmEmitcode.uo: Mixture.ui Instruct.uo Prim.uo CmmAST.uo Pr_zam.uo Fnlib.ui \
-    Const.uo 
-CmmBack.uo: Sort.ui Pr_lam.ui Stack.ui CmmAST.uo Lambda.uo 
-CmmPrint.uo: CmmPrint.ui Wpp.ui CmmAST.uo 
-CmmPrint.ui: Wpp.ui CmmAST.uo 
-Predef.uo: Const.uo 
+    Const.uo
+CmmBack.uo: Sort.ui Pr_lam.ui Stack.ui CmmAST.uo Lambda.uo
+CmmPrint.uo: CmmPrint.ui Wpp.ui CmmAST.uo
+CmmPrint.ui: Wpp.ui CmmAST.uo
+Predef.uo: Const.uo
 Lexer.uo: Lexer.ui Parser.ui Const.uo Fnlib.ui Config.uo Stack.ui \
-    Mixture.ui Hasht.ui Memory.uo 
-Parser.ui: Asynt.uo Const.uo 
+    Mixture.ui Hasht.ui Memory.uo
+Parser.ui: Asynt.uo Const.uo
 Parser.uo: Parser.ui Asynt.uo Const.uo Fnlib.ui Config.uo Types.ui \
-    Asyntfn.ui Globals.uo Location.ui Mixture.ui 
-Config.uo: Fnlib.ui 
-Filename.uo: Filename.ui 
+    Asyntfn.ui Globals.uo Location.ui Mixture.ui
+Config.uo: Fnlib.ui
+Filename.uo: Filename.ui
 Units.uo: Units.ui Const.uo Fnlib.ui Config.uo Globals.uo Location.ui \
-    Mixture.ui Hasht.ui Filename.ui 
-Units.ui: Const.uo Fnlib.ui Globals.uo Location.ui Mixture.ui Hasht.ui 
+    Mixture.ui Hasht.ui Filename.ui
+Units.ui: Const.uo Fnlib.ui Globals.uo Location.ui Mixture.ui Hasht.ui
 Types.uo: Types.ui Const.uo Fnlib.ui Config.uo Globals.uo Smlprim.uo \
-    Location.ui Mixture.ui Units.ui Hasht.ui 
+    Location.ui Mixture.ui Units.ui Hasht.ui
 Types.ui: Const.uo Fnlib.ui Globals.uo Smlprim.uo Location.ui Mixture.ui \
-    Units.ui 
+    Units.ui
 Tr_env.uo: Tr_env.ui Asynt.uo Const.uo Fnlib.ui Prim.uo Types.ui Asyntfn.ui \
-    Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo 
-Tr_env.ui: Asynt.uo Const.uo Mixture.ui Lambda.uo 
-Tr_const.uo: Const.uo Symtable.ui 
+    Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo
+Tr_env.ui: Asynt.uo Const.uo Mixture.ui Lambda.uo
+Tr_const.uo: Const.uo Symtable.ui
 Synchk.uo: Synchk.ui Asynt.uo Const.uo Fnlib.ui Asyntfn.ui Globals.uo \
-    Location.ui Mixture.ui Units.ui 
-Synchk.ui: Asynt.uo 
+    Location.ui Mixture.ui Units.ui
+Synchk.ui: Asynt.uo
 Symtable.uo: Symtable.ui Const.uo Fnlib.ui Config.uo Predef.uo Prim_c.uo \
-    Mixture.ui Hasht.ui Miscsys.ui 
-Symtable.ui: Const.uo 
-Stack.uo: Stack.ui 
-Sort.uo: Sort.ui 
+    Mixture.ui Hasht.ui Miscsys.ui
+Symtable.ui: Const.uo
+Stack.uo: Stack.ui
+Sort.uo: Sort.ui
 Smltop.uo: Smltop.ui Compiler.ui Const.uo Fnlib.ui Patch.uo Emit_phr.uo \
     Rtvals.ui Config.uo Code_dec.uo Lexer.ui Types.ui Globals.uo Smlprim.uo \
     Smlexc.uo Smlperv.ui Opcodes.uo Location.ui Symtable.ui Emitcode.ui \
     Mixture.ui Units.ui Load_phr.ui Hasht.ui Miscsys.ui Memory.uo \
-    Filename.ui Exec_phr.ui 
-Smlprim.uo: Const.uo Prim.uo 
+    Filename.ui Exec_phr.ui
+Smlprim.uo: Const.uo Prim.uo
 Smlperv.uo: Smlperv.ui Const.uo Fnlib.ui Prim.uo Types.ui Globals.uo \
-    Smlprim.uo Smlexc.uo Units.ui Hasht.ui 
-Smlexc.uo: Const.uo Fnlib.ui Config.uo Types.ui Mixture.ui 
+    Smlprim.uo Smlexc.uo Units.ui Hasht.ui
+Smlexc.uo: Const.uo Fnlib.ui Config.uo Types.ui Mixture.ui
 Sigmtch.uo: Sigmtch.ui Front.ui Const.uo Back.ui Fnlib.ui Emit_phr.uo \
-    Prim.uo Types.ui Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo 
-Sigmtch.ui: Units.ui 
+    Prim.uo Types.ui Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo
+Sigmtch.ui: Units.ui
 Rtvals.uo: Rtvals.ui Const.uo Fnlib.ui Config.uo Types.ui Globals.uo \
-    Smlexc.uo Symtable.ui Mixture.ui Units.ui Miscsys.ui Memory.uo 
-Rtvals.ui: Const.uo Types.ui Globals.uo 
-Reloc.uo: Const.uo Buffcode.uo Code_dec.uo Hasht.ui 
-Printexc.uo: Printexc.ui 
-Primdec.uo: Const.uo Fnlib.ui Prim.uo Smlprim.uo 
-Prim_opc.uo: Fnlib.ui Prim.uo Opcodes.uo 
-Prim.uo: Const.uo 
+    Smlexc.uo Symtable.ui Mixture.ui Units.ui Miscsys.ui Memory.uo
+Rtvals.ui: Const.uo Types.ui Globals.uo
+Reloc.uo: Const.uo Buffcode.uo Code_dec.uo Hasht.ui
+Printexc.uo: Printexc.ui
+Primdec.uo: Const.uo Fnlib.ui Prim.uo Smlprim.uo
+Prim_opc.uo: Fnlib.ui Prim.uo Opcodes.uo
+Prim.uo: Const.uo
 Pr_zam.uo: Asynt.uo Const.uo Fnlib.ui Config.uo Pr_lam.ui Instruct.uo \
-    Mixture.ui 
-Pr_lam.uo: Pr_lam.ui Asynt.uo Const.uo Prim.uo Mixture.ui Lambda.uo 
-Pr_lam.ui: Prim.uo Lambda.uo 
-Patch.uo: Code_dec.uo Symtable.ui 
+    Mixture.ui
+Pr_lam.uo: Pr_lam.ui Asynt.uo Const.uo Prim.uo Mixture.ui Lambda.uo
+Pr_lam.ui: Prim.uo Lambda.uo
+Patch.uo: Code_dec.uo Symtable.ui
 Ovlres.uo: Ovlres.ui Asynt.uo Const.uo Fnlib.ui Prim.uo Types.ui Globals.uo \
-    Smlprim.uo Location.ui Mixture.ui Units.ui 
-Ovlres.ui: Asynt.uo 
-Mixture.uo: Mixture.ui Fnlib.ui Config.uo Hasht.ui Miscsys.ui Filename.ui 
-Mixture.ui: Hasht.ui 
-Miscsys.uo: Miscsys.ui 
+    Smlprim.uo Location.ui Mixture.ui Units.ui
+Ovlres.ui: Asynt.uo
+Mixture.uo: Mixture.ui Fnlib.ui Config.uo Hasht.ui Miscsys.ui Filename.ui
+Mixture.ui: Hasht.ui
+Miscsys.uo: Miscsys.ui
 Match.uo: Match.ui Asynt.uo Const.uo Fnlib.ui Prim.uo Asyntfn.ui Tr_env.ui \
-    Location.ui Mixture.ui Hasht.ui Lambda.uo 
-Match.ui: Asynt.uo Tr_env.ui Location.ui Lambda.uo 
+    Location.ui Mixture.ui Hasht.ui Lambda.uo
+Match.ui: Asynt.uo Tr_env.ui Location.ui Lambda.uo
 Maint.uo: Maint.ui Compiler.ui Fnlib.ui Rtvals.ui Config.uo Types.ui Arg.ui \
     Printexc.ui Smlperv.ui Location.ui Smltop.ui Mixture.ui Units.ui \
-    Miscsys.ui Memory.uo Exec_phr.ui 
+    Miscsys.ui Memory.uo Exec_phr.ui
 Mainl.uo: Fnlib.ui Config.uo Arg.ui Printexc.ui Link.ui Symtable.ui \
-    Readword.uo Mixture.ui Miscsys.ui Filename.ui 
+    Readword.uo Mixture.ui Miscsys.ui Filename.ui
 Mainc.uo: Mainc.ui Compiler.ui Fnlib.ui Config.uo Lexer.ui Types.ui Arg.ui \
     Printexc.ui Smlperv.ui Location.ui Mixture.ui Units.ui Miscsys.ui \
-    Filename.ui 
-Location.uo: Location.ui Fnlib.ui Config.uo Mixture.ui 
+    Filename.ui
+Location.uo: Location.ui Fnlib.ui Config.uo Mixture.ui
 Load_phr.uo: Load_phr.ui Const.uo Reloc.uo Fnlib.ui Buffcode.uo Patch.uo \
     Rtvals.ui Types.ui Opcodes.uo Symtable.ui Labels.uo Emitcode.ui \
-    Instruct.uo Tr_const.uo Mixture.ui Memory.uo 
-Load_phr.ui: Instruct.uo 
+    Instruct.uo Tr_const.uo Mixture.ui Memory.uo
+Load_phr.ui: Instruct.uo
 Link.uo: Link.ui Const.uo Fnlib.ui Patch.uo Config.uo Code_dec.uo \
     Opcodes.uo Symtable.ui Tr_const.uo Mixture.ui Hasht.ui Miscsys.ui \
-    Filename.ui 
-Lexer.ui: Parser.ui 
-Lambda.uo: Const.uo Prim.uo Instruct.uo 
-Labels.uo: Fnlib.ui Buffcode.uo Instruct.uo 
-Instruct.uo: Const.uo Config.uo Prim.uo 
+    Filename.ui
+Lexer.ui: Parser.ui
+Lambda.uo: Const.uo Prim.uo Instruct.uo
+Labels.uo: Fnlib.ui Buffcode.uo Instruct.uo
+Instruct.uo: Const.uo Config.uo Prim.uo
 Infixst.uo: Infixst.ui Asynt.uo Const.uo Fnlib.ui Globals.uo Location.ui \
-    Mixture.ui 
-Infixst.ui: Asynt.uo Fnlib.ui Globals.uo Location.ui Mixture.ui 
+    Mixture.ui
+Infixst.ui: Asynt.uo Fnlib.ui Globals.uo Location.ui Mixture.ui
 Infixres.uo: Infixres.ui Asynt.uo Primdec.uo Const.uo Fnlib.ui Infixst.ui \
     Types.ui Asyntfn.ui Globals.uo Smlprim.uo Smlexc.uo Location.ui \
-    Mixture.ui Units.ui 
-Infixres.ui: Asynt.uo Globals.uo 
-Hasht.uo: Hasht.ui 
-Globals.uo: Const.uo Fnlib.ui Smlprim.uo Mixture.ui 
+    Mixture.ui Units.ui
+Infixres.ui: Asynt.uo Globals.uo
+Hasht.uo: Hasht.ui
+Globals.uo: Const.uo Fnlib.ui Smlprim.uo Mixture.ui
 Front.uo: Front.ui Asynt.uo Const.uo Fnlib.ui Config.uo Prim.uo Types.ui \
     Asyntfn.ui Globals.uo Smlprim.uo Smlexc.uo Tr_env.ui Location.ui \
-    Match.ui Mixture.ui Units.ui Lambda.uo 
-Front.ui: Asynt.uo Globals.uo Smlprim.uo Tr_env.ui Lambda.uo 
-Fnlib.uo: Fnlib.ui 
+    Match.ui Mixture.ui Units.ui Lambda.uo
+Front.ui: Asynt.uo Globals.uo Smlprim.uo Tr_env.ui Lambda.uo
+Fnlib.uo: Fnlib.ui
 Exec_phr.uo: Exec_phr.ui Asynt.uo Front.ui Compiler.ui Const.uo Back.ui \
     Fnlib.ui Pr_zam.uo Infixst.ui Elab.ui Rtvals.ui Types.ui Ovlres.ui \
     Globals.uo Tr_env.ui Symtable.ui Mixture.ui Units.ui Load_phr.ui \
-    Infixres.ui Miscsys.ui 
-Exec_phr.ui: Asynt.uo 
+    Infixres.ui Miscsys.ui
+Exec_phr.ui: Asynt.uo
 Emitcode.uo: Emitcode.ui Const.uo Reloc.uo Fnlib.ui Buffcode.uo Config.uo \
-    Prim.uo Opcodes.uo Labels.uo Instruct.uo Mixture.ui Prim_opc.uo 
-Emitcode.ui: Instruct.uo 
+    Prim.uo Opcodes.uo Labels.uo Instruct.uo Mixture.ui Prim_opc.uo
+Emitcode.ui: Instruct.uo
 Emit_phr.uo: CmmPrint.ui Code_dec.uo Wpp.ui Instruct.uo CmmAST.uo \
-    CmmEmitcode.uo 
+    CmmEmitcode.uo
 Elab.uo: Elab.ui Asynt.uo Primdec.uo Sort.ui Synchk.ui Const.uo Fnlib.ui \
     Config.uo Types.ui Asyntfn.ui Globals.uo Smlprim.uo Smlexc.uo \
-    Location.ui Mixture.ui Units.ui 
-Elab.ui: Asynt.uo Globals.uo 
-Const.uo: Fnlib.ui Config.uo Mixture.ui 
+    Location.ui Mixture.ui Units.ui
+Elab.ui: Asynt.uo Globals.uo
+Const.uo: Fnlib.ui Config.uo Mixture.ui
 Compiler.uo: Compiler.ui Asynt.uo Front.ui Parser.ui Const.uo Back.ui \
     Fnlib.ui Pr_zam.uo Elab.ui Emit_phr.uo Lexer.ui Config.uo Sigmtch.ui \
     Types.ui Ovlres.ui Globals.uo Smlperv.ui Tr_env.ui Location.ui \
-    Mixture.ui Units.ui Infixres.ui Hasht.ui 
-Compiler.ui: Asynt.uo Globals.uo Mixture.ui 
-Code_dec.uo: Const.uo Mixture.ui Hasht.ui 
-Buffcode.uo: Fnlib.ui Config.uo Opcodes.uo Mixture.ui 
+    Mixture.ui Units.ui Infixres.ui Hasht.ui
+Compiler.ui: Asynt.uo Globals.uo Mixture.ui
+Code_dec.uo: Const.uo Mixture.ui Hasht.ui
+Buffcode.uo: Fnlib.ui Config.uo Opcodes.uo Mixture.ui
 Back.uo: Back.ui Sort.ui Const.uo Fnlib.ui Prim.uo Instruct.uo Stack.ui \
-    Mixture.ui Lambda.uo 
-Back.ui: Instruct.uo Lambda.uo 
+    Mixture.ui Lambda.uo
+Back.ui: Instruct.uo Lambda.uo
 Asyntfn.uo: Asyntfn.ui Asynt.uo Const.uo Fnlib.ui Types.ui Globals.uo \
-    Location.ui Mixture.ui 
+    Location.ui Mixture.ui
 Asyntfn.ui: Asynt.uo Const.uo Fnlib.ui Types.ui Globals.uo Location.ui \
-    Mixture.ui 
-Arg.uo: Arg.ui Fnlib.ui Miscsys.ui 
+    Mixture.ui
+Arg.uo: Arg.ui Fnlib.ui Miscsys.ui
 Asynt.uo: Const.uo Fnlib.ui Types.ui Globals.uo Location.ui Mixture.ui \
-    Lambda.uo 
+    Lambda.uo

--- a/src/compiler/Makefile
+++ b/src/compiler/Makefile
@@ -84,14 +84,14 @@ mosmllnk.dos: $(L_OBJS)
 mosmllnk.w32: $(L_OBJS)
 	$(MOSMLL) $(LINKFLAGS) -o mosmllnk.w32 Mainl.uo
 
-Predef.sml : $(CAMLRT)/globals.h 
+Predef.sml : $(CAMLRT)/globals.h
 	$(PERL) $(MOSMLTOOLS)/mksmlpre $(CAMLRT)/globals.h > Predef.sml
 
 Prim_c.sml : $(CAMLRT)/primitives
 	$(PERL) $(MOSMLTOOLS)/mksmlprc $(CAMLRT)/primitives > Prim_c.sml
 
 mosmltop: $(COMP_OBJS) $(T_OBJS)
-	$(MOSMLL) $(LINKFLAGS) -o mosmltop Maint.uo 
+	$(MOSMLL) $(LINKFLAGS) -o mosmltop Maint.uo
 
 mosmltop.dos: $(COMP_OBJS) $(T_OBJS)
 	$(MOSMLLDOS) $(LINKFLAGS) -o mosmltop Maint.uo
@@ -136,8 +136,8 @@ promote:
 	test -f ../mosmllnk.orig || cp ../mosmllnk ../mosmllnk.orig
 	test -f ../mosmllex.orig || cp ../mosmllex ../mosmllex.orig
 	#$(MOSMLL) $(LINKFLAGS) -o mosmlcmp $(C_LIBOBJS) $(COMP_OBJS) $(C_OBJS)
-	#$(MOSMLL) $(LINKFLAGS) -o mosmllnk $(L_LIBOBJS) $(L_OBJS) 
-	#$(MOSMLL) $(LINKFLAGS) -o mosmltop $(T_LIBOBJS) $(T_OBJS) 
+	#$(MOSMLL) $(LINKFLAGS) -o mosmllnk $(L_LIBOBJS) $(L_OBJS)
+	#$(MOSMLL) $(LINKFLAGS) -o mosmltop $(T_LIBOBJS) $(T_OBJS)
 	test -f mosmllnk && cp mosmllnk ../mosmllnk
 	test -f mosmlcmp && cp mosmlcmp ../mosmlcmp
 	test -f ../lex/mosmllex && cp ../lex/mosmllex ../mosmllex
@@ -157,139 +157,139 @@ depend: Filename.sml Config.sml Opcodes.sml Parser.sml Parser.sig Lexer.sml \
 
 regress:
 	echo "building current lib"
-	cd ../mosmllib; make -s current
+	cd ../mosmllib; $(MAKE) -s current
 	echo "testing current lib"
-	cd ../mosmllib/test; make -s current  || echo "results differ"
+	cd ../mosmllib/test; $(MAKE) -s current  || echo "results differ"
 	echo "testing current test"
-	cd ../test; make -s current || echo "results differ"
+	cd ../test; $(MAKE) -s current || echo "results differ"
 	echo "testing current compiler test"
-	cd test; make -s current || echo "results differ"
+	cd test; $(MAKE) -s current || echo "results differ"
 
 ### DO NOT DELETE THIS LINE
-Predef.uo: Const.uo 
+Predef.uo: Const.uo
 Lexer.uo: Lexer.ui Parser.ui Const.uo Fnlib.ui Config.uo Stack.ui \
-    Mixture.ui Hasht.ui Memory.uo 
-Parser.ui: Asynt.uo Const.uo 
+    Mixture.ui Hasht.ui Memory.uo
+Parser.ui: Asynt.uo Const.uo
 Parser.uo: Parser.ui Asynt.uo Const.uo Fnlib.ui Config.uo Types.ui \
-    Asyntfn.ui Globals.uo Location.ui Mixture.ui 
-Config.uo: Fnlib.ui 
-Filename.uo: Filename.ui 
+    Asyntfn.ui Globals.uo Location.ui Mixture.ui
+Config.uo: Fnlib.ui
+Filename.uo: Filename.ui
 Units.uo: Units.ui Const.uo Fnlib.ui Config.uo Globals.uo Location.ui \
-    Mixture.ui Hasht.ui Filename.ui 
-Units.ui: Const.uo Fnlib.ui Globals.uo Location.ui Mixture.ui Hasht.ui 
+    Mixture.ui Hasht.ui Filename.ui
+Units.ui: Const.uo Fnlib.ui Globals.uo Location.ui Mixture.ui Hasht.ui
 Types.uo: Types.ui Const.uo Fnlib.ui Config.uo Globals.uo Smlprim.uo \
-    Location.ui Mixture.ui Units.ui Hasht.ui 
+    Location.ui Mixture.ui Units.ui Hasht.ui
 Types.ui: Const.uo Fnlib.ui Globals.uo Smlprim.uo Location.ui Mixture.ui \
-    Units.ui 
+    Units.ui
 Tr_env.uo: Tr_env.ui Asynt.uo Const.uo Fnlib.ui Prim.uo Types.ui Asyntfn.ui \
-    Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo 
-Tr_env.ui: Asynt.uo Const.uo Mixture.ui Lambda.uo 
-Tr_const.uo: Const.uo Symtable.ui 
+    Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo
+Tr_env.ui: Asynt.uo Const.uo Mixture.ui Lambda.uo
+Tr_const.uo: Const.uo Symtable.ui
 Synchk.uo: Synchk.ui Asynt.uo Const.uo Fnlib.ui Asyntfn.ui Globals.uo \
-    Location.ui Mixture.ui Units.ui 
-Synchk.ui: Asynt.uo 
+    Location.ui Mixture.ui Units.ui
+Synchk.ui: Asynt.uo
 Symtable.uo: Symtable.ui Const.uo Fnlib.ui Config.uo Predef.uo Prim_c.uo \
-    Mixture.ui Hasht.ui Miscsys.ui 
-Symtable.ui: Const.uo 
-Stack.uo: Stack.ui 
-Sort.uo: Sort.ui 
+    Mixture.ui Hasht.ui Miscsys.ui
+Symtable.ui: Const.uo
+Stack.uo: Stack.ui
+Sort.uo: Sort.ui
 Smltop.uo: Smltop.ui Compiler.ui Const.uo Fnlib.ui Patch.uo Emit_phr.uo \
     Rtvals.ui Config.uo Code_dec.uo Lexer.ui Types.ui Globals.uo Smlprim.uo \
     Smlexc.uo Smlperv.ui Opcodes.uo Location.ui Symtable.ui Emitcode.ui \
     Mixture.ui Units.ui Load_phr.ui Hasht.ui Miscsys.ui Memory.uo \
-    Filename.ui Exec_phr.ui 
-Smlprim.uo: Const.uo Prim.uo 
+    Filename.ui Exec_phr.ui
+Smlprim.uo: Const.uo Prim.uo
 Smlperv.uo: Smlperv.ui Const.uo Fnlib.ui Prim.uo Types.ui Globals.uo \
-    Smlprim.uo Smlexc.uo Units.ui Hasht.ui 
-Smlexc.uo: Const.uo Fnlib.ui Config.uo Types.ui Mixture.ui 
+    Smlprim.uo Smlexc.uo Units.ui Hasht.ui
+Smlexc.uo: Const.uo Fnlib.ui Config.uo Types.ui Mixture.ui
 Sigmtch.uo: Sigmtch.ui Front.ui Const.uo Back.ui Fnlib.ui Emit_phr.uo \
-    Prim.uo Types.ui Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo 
-Sigmtch.ui: Units.ui 
+    Prim.uo Types.ui Globals.uo Mixture.ui Units.ui Hasht.ui Lambda.uo
+Sigmtch.ui: Units.ui
 Rtvals.uo: Rtvals.ui Const.uo Fnlib.ui Config.uo Types.ui Globals.uo \
-    Smlexc.uo Symtable.ui Mixture.ui Units.ui Miscsys.ui Memory.uo 
-Rtvals.ui: Const.uo Types.ui Globals.uo 
-Reloc.uo: Const.uo Buffcode.uo Code_dec.uo Hasht.ui 
-Printexc.uo: Printexc.ui 
-Primdec.uo: Const.uo Fnlib.ui Prim.uo Smlprim.uo 
-Prim_opc.uo: Fnlib.ui Prim.uo Opcodes.uo 
-Prim.uo: Const.uo 
+    Smlexc.uo Symtable.ui Mixture.ui Units.ui Miscsys.ui Memory.uo
+Rtvals.ui: Const.uo Types.ui Globals.uo
+Reloc.uo: Const.uo Buffcode.uo Code_dec.uo Hasht.ui
+Printexc.uo: Printexc.ui
+Primdec.uo: Const.uo Fnlib.ui Prim.uo Smlprim.uo
+Prim_opc.uo: Fnlib.ui Prim.uo Opcodes.uo
+Prim.uo: Const.uo
 Pr_zam.uo: Asynt.uo Const.uo Fnlib.ui Config.uo Pr_lam.ui Instruct.uo \
-    Mixture.ui 
-Pr_lam.uo: Pr_lam.ui Asynt.uo Const.uo Prim.uo Mixture.ui Lambda.uo 
-Pr_lam.ui: Prim.uo Lambda.uo 
-Patch.uo: Code_dec.uo Symtable.ui 
+    Mixture.ui
+Pr_lam.uo: Pr_lam.ui Asynt.uo Const.uo Prim.uo Mixture.ui Lambda.uo
+Pr_lam.ui: Prim.uo Lambda.uo
+Patch.uo: Code_dec.uo Symtable.ui
 Ovlres.uo: Ovlres.ui Asynt.uo Const.uo Fnlib.ui Prim.uo Types.ui Globals.uo \
-    Smlprim.uo Location.ui Mixture.ui Units.ui 
-Ovlres.ui: Asynt.uo 
-Mixture.uo: Mixture.ui Fnlib.ui Config.uo Hasht.ui Miscsys.ui Filename.ui 
-Mixture.ui: Hasht.ui 
-Miscsys.uo: Miscsys.ui 
+    Smlprim.uo Location.ui Mixture.ui Units.ui
+Ovlres.ui: Asynt.uo
+Mixture.uo: Mixture.ui Fnlib.ui Config.uo Hasht.ui Miscsys.ui Filename.ui
+Mixture.ui: Hasht.ui
+Miscsys.uo: Miscsys.ui
 Match.uo: Match.ui Asynt.uo Const.uo Fnlib.ui Prim.uo Asyntfn.ui Tr_env.ui \
-    Location.ui Mixture.ui Hasht.ui Lambda.uo 
-Match.ui: Asynt.uo Tr_env.ui Location.ui Lambda.uo 
+    Location.ui Mixture.ui Hasht.ui Lambda.uo
+Match.ui: Asynt.uo Tr_env.ui Location.ui Lambda.uo
 Maint.uo: Maint.ui Compiler.ui Fnlib.ui Rtvals.ui Config.uo Types.ui Arg.ui \
     Printexc.ui Smlperv.ui Location.ui Smltop.ui Mixture.ui Units.ui \
-    Miscsys.ui Memory.uo Exec_phr.ui 
+    Miscsys.ui Memory.uo Exec_phr.ui
 Mainl.uo: Fnlib.ui Config.uo Arg.ui Printexc.ui Link.ui Symtable.ui \
-    Readword.uo Mixture.ui Miscsys.ui Filename.ui 
+    Readword.uo Mixture.ui Miscsys.ui Filename.ui
 Mainc.uo: Mainc.ui Compiler.ui Fnlib.ui Config.uo Lexer.ui Types.ui Arg.ui \
     Printexc.ui Smlperv.ui Location.ui Mixture.ui Units.ui Miscsys.ui \
-    Filename.ui 
-Location.uo: Location.ui Fnlib.ui Config.uo Mixture.ui 
+    Filename.ui
+Location.uo: Location.ui Fnlib.ui Config.uo Mixture.ui
 Load_phr.uo: Load_phr.ui Const.uo Reloc.uo Fnlib.ui Buffcode.uo Patch.uo \
     Rtvals.ui Types.ui Opcodes.uo Symtable.ui Labels.uo Emitcode.ui \
-    Instruct.uo Tr_const.uo Mixture.ui Memory.uo 
-Load_phr.ui: Instruct.uo 
+    Instruct.uo Tr_const.uo Mixture.ui Memory.uo
+Load_phr.ui: Instruct.uo
 Link.uo: Link.ui Const.uo Fnlib.ui Patch.uo Config.uo Code_dec.uo \
     Opcodes.uo Symtable.ui Tr_const.uo Mixture.ui Hasht.ui Miscsys.ui \
-    Filename.ui 
-Lexer.ui: Parser.ui 
-Lambda.uo: Const.uo Prim.uo Instruct.uo 
-Labels.uo: Fnlib.ui Buffcode.uo Instruct.uo 
-Instruct.uo: Const.uo Config.uo Prim.uo 
+    Filename.ui
+Lexer.ui: Parser.ui
+Lambda.uo: Const.uo Prim.uo Instruct.uo
+Labels.uo: Fnlib.ui Buffcode.uo Instruct.uo
+Instruct.uo: Const.uo Config.uo Prim.uo
 Infixst.uo: Infixst.ui Asynt.uo Const.uo Fnlib.ui Globals.uo Location.ui \
-    Mixture.ui 
-Infixst.ui: Asynt.uo Fnlib.ui Globals.uo Location.ui Mixture.ui 
+    Mixture.ui
+Infixst.ui: Asynt.uo Fnlib.ui Globals.uo Location.ui Mixture.ui
 Infixres.uo: Infixres.ui Asynt.uo Primdec.uo Const.uo Fnlib.ui Infixst.ui \
     Types.ui Asyntfn.ui Globals.uo Smlprim.uo Smlexc.uo Location.ui \
-    Mixture.ui Units.ui 
-Infixres.ui: Asynt.uo Globals.uo 
-Hasht.uo: Hasht.ui 
-Globals.uo: Const.uo Fnlib.ui Smlprim.uo Mixture.ui 
+    Mixture.ui Units.ui
+Infixres.ui: Asynt.uo Globals.uo
+Hasht.uo: Hasht.ui
+Globals.uo: Const.uo Fnlib.ui Smlprim.uo Mixture.ui
 Front.uo: Front.ui Asynt.uo Const.uo Fnlib.ui Config.uo Prim.uo Types.ui \
     Asyntfn.ui Globals.uo Smlprim.uo Smlexc.uo Tr_env.ui Location.ui \
-    Match.ui Mixture.ui Units.ui Lambda.uo 
-Front.ui: Asynt.uo Globals.uo Smlprim.uo Tr_env.ui Lambda.uo 
-Fnlib.uo: Fnlib.ui 
+    Match.ui Mixture.ui Units.ui Lambda.uo
+Front.ui: Asynt.uo Globals.uo Smlprim.uo Tr_env.ui Lambda.uo
+Fnlib.uo: Fnlib.ui
 Exec_phr.uo: Exec_phr.ui Asynt.uo Front.ui Compiler.ui Const.uo Back.ui \
     Fnlib.ui Pr_zam.uo Infixst.ui Elab.ui Rtvals.ui Types.ui Ovlres.ui \
     Globals.uo Tr_env.ui Symtable.ui Mixture.ui Units.ui Load_phr.ui \
-    Infixres.ui Miscsys.ui 
-Exec_phr.ui: Asynt.uo 
+    Infixres.ui Miscsys.ui
+Exec_phr.ui: Asynt.uo
 Emitcode.uo: Emitcode.ui Const.uo Reloc.uo Fnlib.ui Buffcode.uo Config.uo \
-    Prim.uo Opcodes.uo Labels.uo Instruct.uo Mixture.ui Prim_opc.uo 
-Emitcode.ui: Instruct.uo 
+    Prim.uo Opcodes.uo Labels.uo Instruct.uo Mixture.ui Prim_opc.uo
+Emitcode.ui: Instruct.uo
 Emit_phr.uo: Const.uo Reloc.uo Buffcode.uo Code_dec.uo Labels.uo \
-    Emitcode.ui Instruct.uo Mixture.ui 
+    Emitcode.ui Instruct.uo Mixture.ui
 Elab.uo: Elab.ui Asynt.uo Primdec.uo Sort.ui Synchk.ui Const.uo Fnlib.ui \
     Config.uo Types.ui Asyntfn.ui Globals.uo Smlprim.uo Smlexc.uo \
-    Location.ui Mixture.ui Units.ui 
-Elab.ui: Asynt.uo Globals.uo 
-Const.uo: Fnlib.ui Config.uo Mixture.ui 
+    Location.ui Mixture.ui Units.ui
+Elab.ui: Asynt.uo Globals.uo
+Const.uo: Fnlib.ui Config.uo Mixture.ui
 Compiler.uo: Compiler.ui Asynt.uo Front.ui Parser.ui Const.uo Back.ui \
     Fnlib.ui Pr_zam.uo Elab.ui Emit_phr.uo Lexer.ui Config.uo Sigmtch.ui \
     Types.ui Ovlres.ui Globals.uo Smlperv.ui Tr_env.ui Location.ui \
-    Mixture.ui Units.ui Infixres.ui Hasht.ui 
-Compiler.ui: Asynt.uo Globals.uo Mixture.ui 
-Code_dec.uo: Const.uo Mixture.ui Hasht.ui 
-Buffcode.uo: Fnlib.ui Config.uo Opcodes.uo Mixture.ui 
+    Mixture.ui Units.ui Infixres.ui Hasht.ui
+Compiler.ui: Asynt.uo Globals.uo Mixture.ui
+Code_dec.uo: Const.uo Mixture.ui Hasht.ui
+Buffcode.uo: Fnlib.ui Config.uo Opcodes.uo Mixture.ui
 Back.uo: Back.ui Sort.ui Const.uo Fnlib.ui Prim.uo Instruct.uo Stack.ui \
-    Mixture.ui Lambda.uo 
-Back.ui: Instruct.uo Lambda.uo 
+    Mixture.ui Lambda.uo
+Back.ui: Instruct.uo Lambda.uo
 Asyntfn.uo: Asyntfn.ui Asynt.uo Const.uo Fnlib.ui Types.ui Globals.uo \
-    Location.ui Mixture.ui 
+    Location.ui Mixture.ui
 Asyntfn.ui: Asynt.uo Const.uo Fnlib.ui Types.ui Globals.uo Location.ui \
-    Mixture.ui 
-Arg.uo: Arg.ui Fnlib.ui Miscsys.ui 
+    Mixture.ui
+Arg.uo: Arg.ui Fnlib.ui Miscsys.ui
 Asynt.uo: Const.uo Fnlib.ui Types.ui Globals.uo Location.ui Mixture.ui \
-    Lambda.uo 
+    Lambda.uo

--- a/src/config/auto-aux/sizes.c
+++ b/src/config/auto-aux/sizes.c
@@ -4,6 +4,6 @@ int main(argc, argv)
      int argc;
      char ** argv;
 {
-  printf("%d %d %d\n", sizeof(int), sizeof(long), sizeof(long *));
+  printf("%lu %lu %lu\n", sizeof(int), sizeof(long), sizeof(long *));
   return 0;
 }

--- a/src/config/autoconf
+++ b/src/config/autoconf
@@ -178,7 +178,7 @@ fi
 # Test for .h files
 
 test_header() {
-    if echo "#include <$1> " | gcc -E - > /dev/null 2> /dev/null; then
+    if echo "#include <$1> " | $cc -E - > /dev/null 2> /dev/null; then
         echo "$1 found."
         echo "#define $2" >> s.h
     else

--- a/src/dynlibs/Makefile
+++ b/src/dynlibs/Makefile
@@ -1,53 +1,53 @@
 
 all:
-	cd interface; make
-	cd intinf; make
-	cd mgd; make
-	cd mgdbm; make
-	cd mmysql; make
-	cd mpq; make
-	cd mregex; make
-	cd msocket; make
-	cd munix; make
+	cd interface; $(MAKE)
+	cd intinf; $(MAKE)
+	cd mgd; $(MAKE)
+	cd mgdbm; $(MAKE)
+	cd mmysql; $(MAKE)
+	cd mpq; $(MAKE)
+	cd mregex; $(MAKE)
+	cd msocket; $(MAKE)
+	cd munix; $(MAKE)
 
 install:
-	cd intinf; make install
-	cd mgd; make install
-	cd mgdbm; make install
-	cd mmysql; make install
-	cd mpq; make install
-	cd mregex; make install
-	cd msocket; make install
-	cd munix; make install
+	cd intinf; $(MAKE) install
+	cd mgd; $(MAKE) install
+	cd mgdbm; $(MAKE) install
+	cd mmysql; $(MAKE) install
+	cd mpq; $(MAKE) install
+	cd mregex; $(MAKE) install
+	cd msocket; $(MAKE) install
+	cd munix; $(MAKE) install
 
 uninstall:
-	cd intinf; make uninstall
-	cd mgd; make uninstall
-	cd mgdbm; make uninstall
-	cd mmysql; make uninstall
-	cd mpq; make uninstall
-	cd mregex; make uninstall
-	cd msocket; make uninstall
-	cd munix; make uninstall
+	cd intinf; $(MAKE) uninstall
+	cd mgd; $(MAKE) uninstall
+	cd mgdbm; $(MAKE) uninstall
+	cd mmysql; $(MAKE) uninstall
+	cd mpq; $(MAKE) uninstall
+	cd mregex; $(MAKE) uninstall
+	cd msocket; $(MAKE) uninstall
+	cd munix; $(MAKE) uninstall
 
 test:
-	cd interface; make test
-	cd intinf; make test
-	cd mgd; make test
-	cd mgdbm; make test
-	cd mmysql; make test
-	cd mpq; make test
-	cd mregex; make test
-	cd munix; make test
+	cd interface; $(MAKE) test
+	cd intinf; $(MAKE) test
+	cd mgd; $(MAKE) test
+	cd mgdbm; $(MAKE) test
+	cd mmysql; $(MAKE) test
+	cd mpq; $(MAKE) test
+	cd mregex; $(MAKE) test
+	cd munix; $(MAKE) test
 
 clean:
-	cd crypt; make clean
-	cd interface; make clean
-	cd intinf; make clean
-	cd mgd; make clean
-	cd mgdbm; make clean
-	cd mmysql; make clean
-	cd mpq; make clean
-	cd mregex; make clean
-	cd msocket; make clean
-	cd munix; make clean
+	cd crypt; $(MAKE) clean
+	cd interface; $(MAKE) clean
+	cd intinf; $(MAKE) clean
+	cd mgd; $(MAKE) clean
+	cd mgdbm; $(MAKE) clean
+	cd mmysql; $(MAKE) clean
+	cd mpq; $(MAKE) clean
+	cd mregex; $(MAKE) clean
+	cd msocket; $(MAKE) clean
+	cd munix; $(MAKE) clean

--- a/src/dynlibs/mregex/Makefile
+++ b/src/dynlibs/mregex/Makefile
@@ -20,8 +20,8 @@ mregex.o: mregex.c
 	$(CC) $(CFLAGS) -c -o mregex.o mregex.c
 
 libmregex.so: mregex.o
-	(cd regex-0.12; ./configure; make regex.o)
-	$(DYNLD) -o libmregex.so regex-0.12/regex.o mregex.o 
+	(cd regex-0.12; ./configure; $(MAKE) regex.o)
+	$(DYNLD) -o libmregex.so regex-0.12/regex.o mregex.o
 
 install:
 	${INSTALL_DATA} libmregex.so $(LIBDIR)
@@ -38,11 +38,11 @@ clean:
 	rm -f Makefile.bak
 	(cd regex-0.12; (test -f Makefile && make clean || test 1))
 
-depend: 
+depend:
 	rm -f Makefile.bak
 	mv Makefile Makefile.bak
 	$(MOSMLTOOLS)/cutdeps < Makefile.bak > Makefile
 	$(MOSMLTOOLS)/mosmldep >> Makefile
 
 ### DO NOT DELETE THIS LINE
-Regex.uo: Regex.ui 
+Regex.uo: Regex.ui

--- a/src/launch/Makefile
+++ b/src/launch/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.inc
 
-all: mosml mosmlc mosmllex camlexec testprog 
+all: mosml mosmlc mosmllex camlexec testprog
 
 # header cannot be generated until camlrunm is installed in $(BINDIR)...
 
@@ -38,7 +38,7 @@ mosml: mosml.tpl
 	sed -e "s|LIBDIR|$(LIBDIR)|" -e "s|BINDIR|$(BINDIR)|" mosml.tpl > mosml
 
 mosmlc: mosmlc.tpl
-	sed -e "s|LIBDIR|$(LIBDIR)|" -e "s|BINDIR|$(BINDIR)|" -e "s|VERSION|$(VERSION)|" mosmlc.tpl > mosmlc
+	sed -e "s|LIBDIR|$(LIBDIR)|" -e "s|BINDIR|$(BINDIR)|" -e "s|VERSION|$(VERSION)|" -e "s|CC|$(CC)|" mosmlc.tpl > mosmlc
 
 mosmllex: mosmllex.tpl
 	sed -e "s|LIBDIR|$(LIBDIR)|" -e "s|BINDIR|$(BINDIR)|" mosmllex.tpl > mosmllex
@@ -58,4 +58,3 @@ clean:
 	rm -f camlexec.c camlexec$(EXE) mosmlc mosml mosmllex testprog testprog.u[io]
 
 depend:
-

--- a/src/launch/mosmlc.tpl
+++ b/src/launch/mosmlc.tpl
@@ -9,7 +9,7 @@ compopt="-conservative"
 linkopt=""
 custom=""
 linkfiles=""
-cc=gcc
+cc=CC
 ccfiles=""
 cclib=""
 ccopt=""
@@ -22,7 +22,7 @@ while : ; do
       break;;
     *.sml)
       $mosmlbin/camlrunm $stdlib/mosmlcmp -stdlib $stdlib $includes $compopt $context $1 || exit $?
-      case $1 in 
+      case $1 in
 	    */*)
 	    context="$context `dirname $1`/`basename $1 .sml`.ui"
 	    ;;
@@ -32,7 +32,7 @@ while : ; do
       linkfiles="$linkfiles $1";;
     *.sig)
       $mosmlbin/camlrunm $stdlib/mosmlcmp -stdlib $stdlib $includes $compopt $context $1 || exit $?
-      case $1 in 
+      case $1 in
 	    */*)
 	    context="$context `dirname $1`/`basename $1 .sig`.ui"
 	    ;;
@@ -48,7 +48,7 @@ while : ; do
     -structure|-toplevel)
       context="$context $1";;
     -c)
-      linkalso=false;;      
+      linkalso=false;;
     -I|-include)
       includes="$includes -I $2"
       shift;;
@@ -75,7 +75,7 @@ while : ; do
       linkout=$2
       shift;;
     -standalone)
-      linkopt="$linkopt $1";;      
+      linkopt="$linkopt $1";;
     -stdlib)
       stdlib=$2
       shift;;

--- a/src/lex/Makefile
+++ b/src/lex/Makefile
@@ -34,7 +34,7 @@ clean:
 	rm -f Grammar.output
 	rm -f Scanner.sml
 	rm -f Makefile.bak
-	cd test; make clean
+	cd test; $(MAKE) clean
 
 install:
 	${INSTALL_DATA} mosmllex $(DESTDIR)$(LIBDIR)
@@ -52,11 +52,11 @@ depend: Scanner.sml Grammar.sml Grammar.sig
 	$(MOSMLDEP) >> Makefile
 
 ### DO NOT DELETE THIS LINE
-Grammar.ui: Syntax.uo 
-Grammar.uo: Grammar.ui Syntax.uo Gram_aux.uo 
-Scanner.uo: Scanner.ui Syntax.uo Scan_aux.uo Grammar.ui 
-Gram_aux.uo: Syntax.uo 
-Output.uo: Syntax.uo 
-Mainlex.uo: Lexgen.uo Syntax.uo Scan_aux.uo Scanner.ui Grammar.ui Output.uo 
-Scanner.ui: Grammar.ui 
-Lexgen.uo: Syntax.uo 
+Grammar.ui: Syntax.uo
+Grammar.uo: Grammar.ui Syntax.uo Gram_aux.uo
+Scanner.uo: Scanner.ui Syntax.uo Scan_aux.uo Grammar.ui
+Gram_aux.uo: Syntax.uo
+Output.uo: Syntax.uo
+Mainlex.uo: Lexgen.uo Syntax.uo Scan_aux.uo Scanner.ui Grammar.ui Output.uo
+Scanner.ui: Grammar.ui
+Lexgen.uo: Syntax.uo

--- a/src/mosmllib/Makefile
+++ b/src/mosmllib/Makefile
@@ -30,15 +30,15 @@ all: Array.uo Array2.uo ArraySlice.uo Arraysort.uo \
 
 # Make with the current compiler
 current:
-	make clean
-	make all MOSMLC=../camlrunm\ ../compiler/mosmlcmp\ -stdlib\ .\ -P\ none
+	$(MAKE) clean
+	$(MAKE) all MOSMLC=../camlrunm\ ../compiler/mosmlcmp\ -stdlib\ .\ -P\ none
 
 clean:
 	rm -f *.ui
 	rm -f *.uo
 	rm -f Makefile.bak
 	rm -f Array.sml FileSys.sml Help.sml Int.sml Mosml.sml
-	rm -f Path.sml Process.sml Strbase.sml 
+	rm -f Path.sml Process.sml Strbase.sml
 	rm -f Vector.sml Word.sml Word8Array.sml Word8Vector.sml Weak.sml
 
 install:
@@ -67,151 +67,151 @@ depend: Array.sml FileSys.sml Help.sml Int.sml Mosml.sml Path.sml \
 OS.ui: FileSys.ui Path.ui Process.ui
 
 ### DO NOT DELETE THIS LINE
-VectorSlice.ui: Vector.ui 
-CommandLine.uo: CommandLine.ui Vector.ui 
-CharVectorSlice.ui: CharVector.ui Substring.ui Char.ui 
-Word8Array.uo: Word8Array.ui List.ui Word8.ui Word8Vector.ui 
-FileSys.uo: FileSys.ui Path.ui List.ui Time.ui 
+VectorSlice.ui: Vector.ui
+CommandLine.uo: CommandLine.ui Vector.ui
+CharVectorSlice.ui: CharVector.ui Substring.ui Char.ui
+Word8Array.uo: Word8Array.ui List.ui Word8.ui Word8Vector.ui
+FileSys.uo: FileSys.ui Path.ui List.ui Time.ui
 Mosmlcookie.uo: Mosmlcookie.ui String.ui List.ui Date.ui Option.ui \
-    Process.ui Substring.ui Bool.ui 
-Bool.uo: Bool.ui StringCvt.ui Char.ui 
+    Process.ui Substring.ui Bool.ui
+Bool.uo: Bool.ui StringCvt.ui Char.ui
 PackRealLittle.uo: PackRealLittle.ui Word8Array.ui Word8ArraySlice.ui \
-    Word8Vector.ui Word8VectorSlice.ui 
-TextIO.ui: StringCvt.ui Char.ui 
+    Word8Vector.ui Word8VectorSlice.ui
+TextIO.ui: StringCvt.ui Char.ui
 Msp.uo: Msp.ui String.ui StringCvt.ui List.ui Option.ui Vector.ui TextIO.ui \
-    Int.ui Mosmlcgi.ui Char.ui 
-AppleScript.uo: AppleScript.ui 
-Regex.uo: Regex.ui Word.ui Dynlib.ui List.ui Vector.ui Substring.ui 
-Time.uo: Time.ui Real.ui StringCvt.ui Char.ui 
-Splaytree.uo: Splaytree.ui 
-Lexing.uo: Lexing.ui CharArray.ui Obj.uo 
-Arraysort.ui: Array.ui 
-CharArraySlice.ui: CharVector.ui CharArray.ui CharVectorSlice.ui 
+    Int.ui Mosmlcgi.ui Char.ui
+AppleScript.uo: AppleScript.ui
+Regex.uo: Regex.ui Word.ui Dynlib.ui List.ui Vector.ui Substring.ui
+Time.uo: Time.ui Real.ui StringCvt.ui Char.ui
+Splaytree.uo: Splaytree.ui
+Lexing.uo: Lexing.ui CharArray.ui Obj.uo
+Arraysort.ui: Array.ui
+CharArraySlice.ui: CharVector.ui CharArray.ui CharVectorSlice.ui
 Mosml.uo: Mosml.ui Timer.ui FileSys.ui BinIO.ui String.ui List.ui Vector.ui \
-    Word8.ui Process.ui Byte.ui TextIO.ui Word8Vector.ui Time.ui 
-StringCvt.uo: StringCvt.ui 
-Process.ui: Time.ui 
-Splaymap.uo: Splaymap.ui Splaytree.ui 
-Misc.ui: Array.ui 
-Nonstdio.ui: BasicIO.ui CharArray.ui Char.ui 
-CharArray.uo: CharArray.ui CharVector.ui Word8Array.ui Char.ui 
-Word.ui: StringCvt.ui 
-Hashset.uo: Hashset.ui List.ui Array.ui 
-Gdimage.uo: Gdimage.ui Dynlib.ui Vector.ui 
-List.uo: List.ui 
-Socket.ui: Word8Array.ui Word8Vector.ui Time.ui 
+    Word8.ui Process.ui Byte.ui TextIO.ui Word8Vector.ui Time.ui
+StringCvt.uo: StringCvt.ui
+Process.ui: Time.ui
+Splaymap.uo: Splaymap.ui Splaytree.ui
+Misc.ui: Array.ui
+Nonstdio.ui: BasicIO.ui CharArray.ui Char.ui
+CharArray.uo: CharArray.ui CharVector.ui Word8Array.ui Char.ui
+Word.ui: StringCvt.ui
+Hashset.uo: Hashset.ui List.ui Array.ui
+Gdimage.uo: Gdimage.ui Dynlib.ui Vector.ui
+List.uo: List.ui
+Socket.ui: Word8Array.ui Word8Vector.ui Time.ui
 Mosmlcgi.uo: Mosmlcgi.ui String.ui StringCvt.ui List.ui Option.ui \
-    Process.ui Substring.ui Splaymap.ui TextIO.ui Int.ui Char.ui 
-Date.ui: StringCvt.ui Time.ui 
-Mysql.ui: Msp.ui Date.ui Word8Array.ui Vector.ui 
+    Process.ui Substring.ui Splaymap.ui TextIO.ui Int.ui Char.ui
+Date.ui: StringCvt.ui Time.ui
+Mysql.ui: Msp.ui Date.ui Word8Array.ui Vector.ui
 Word8ArraySlice.uo: Word8ArraySlice.ui Word8Array.ui Word8.ui \
-    Word8Vector.ui Word8VectorSlice.ui 
-Word8Vector.uo: Word8Vector.ui String.ui List.ui Word8.ui 
-Parsing.ui: Lexing.ui Vector.ui Obj.uo 
-Unix.ui: BinIO.ui Signal.ui OS.ui TextIO.ui 
-Path.uo: Path.ui String.ui CharVector.ui List.ui Substring.ui 
-Gdbm.uo: Gdbm.ui Dynlib.ui List.ui 
-Timer.ui: Time.ui 
+    Word8Vector.ui Word8VectorSlice.ui
+Word8Vector.uo: Word8Vector.ui String.ui List.ui Word8.ui
+Parsing.ui: Lexing.ui Vector.ui Obj.uo
+Unix.ui: BinIO.ui Signal.ui OS.ui TextIO.ui
+Path.uo: Path.ui String.ui CharVector.ui List.ui Substring.ui
+Gdbm.uo: Gdbm.ui Dynlib.ui List.ui
+Timer.ui: Time.ui
 Byte.ui: String.ui Word8Array.ui Word8.ui Word8ArraySlice.ui Substring.ui \
-    Word8Vector.ui Char.ui Word8VectorSlice.ui 
-Intmap.uo: Intmap.ui 
-Polygdbm.ui: Gdbm.ui 
-Word8.uo: Word8.ui Word.ui String.ui StringCvt.ui Char.ui 
-Substring.uo: Substring.ui String.ui Strbase.ui 
-Location.ui: BasicIO.ui Lexing.ui 
-String.ui: Char.ui 
-Binarymap.uo: Binarymap.ui 
-Array.uo: Array.ui List.ui Vector.ui 
-Redblackmap.uo: Redblackmap.ui 
-SML90.uo: SML90.ui String.ui BasicIO.ui 
-Vector.uo: Vector.ui List.ui 
-Real.uo: Real.ui StringCvt.ui Char.ui 
+    Word8Vector.ui Char.ui Word8VectorSlice.ui
+Intmap.uo: Intmap.ui
+Polygdbm.ui: Gdbm.ui
+Word8.uo: Word8.ui Word.ui String.ui StringCvt.ui Char.ui
+Substring.uo: Substring.ui String.ui Strbase.ui
+Location.ui: BasicIO.ui Lexing.ui
+String.ui: Char.ui
+Binarymap.uo: Binarymap.ui
+Array.uo: Array.ui List.ui Vector.ui
+Redblackmap.uo: Redblackmap.ui
+SML90.uo: SML90.ui String.ui BasicIO.ui
+Vector.uo: Vector.ui List.ui
+Real.uo: Real.ui StringCvt.ui Char.ui
 Postgres.uo: Postgres.ui String.ui Real.ui Dynlib.ui StringCvt.ui Msp.ui \
     List.ui Date.ui Option.ui Word8Array.ui Vector.ui Substring.ui Int.ui \
-    Bool.ui 
-BinIO.uo: BinIO.ui Word8.ui TextIO.ui Word8Vector.ui 
-Word8VectorSlice.uo: Word8VectorSlice.ui Word8.ui Word8Vector.ui 
-Option.uo: Option.ui 
-Signal.uo: Signal.ui Word.ui 
+    Bool.ui
+BinIO.uo: BinIO.ui Word8.ui TextIO.ui Word8Vector.ui
+Word8VectorSlice.uo: Word8VectorSlice.ui Word8.ui Word8Vector.ui
+Option.uo: Option.ui
+Signal.uo: Signal.ui Word.ui
 PackRealBig.uo: PackRealBig.ui Word8Array.ui Word8ArraySlice.ui \
-    Word8Vector.ui Word8VectorSlice.ui 
-Int.ui: StringCvt.ui 
-ArraySlice.uo: ArraySlice.ui Vector.ui Array.ui VectorSlice.ui 
+    Word8Vector.ui Word8VectorSlice.ui
+Int.ui: StringCvt.ui
+ArraySlice.uo: ArraySlice.ui Vector.ui Array.ui VectorSlice.ui
 Array2.uo: Array2.ui List.ui Vector.ui Array.ui VectorSlice.ui \
-    ArraySlice.ui 
-CharVector.ui: Char.ui 
-ListPair.uo: ListPair.ui List.ui 
-BinIO.ui: Word8.ui Word8Vector.ui 
-Real.ui: StringCvt.ui 
-Postgres.ui: Msp.ui Date.ui Word8Array.ui Vector.ui 
-Word8VectorSlice.ui: Word8.ui Word8Vector.ui 
-Array.ui: Vector.ui 
+    ArraySlice.ui
+CharVector.ui: Char.ui
+ListPair.uo: ListPair.ui List.ui
+BinIO.ui: Word8.ui Word8Vector.ui
+Real.ui: StringCvt.ui
+Postgres.ui: Msp.ui Date.ui Word8Array.ui Vector.ui
+Word8VectorSlice.ui: Word8.ui Word8Vector.ui
+Array.ui: Vector.ui
 Location.uo: Location.ui CharVector.ui Parsing.ui BasicIO.ui Nonstdio.ui \
-    Lexing.ui 
-String.uo: String.ui List.ui Strbase.ui Char.ui 
-NJ93.uo: NJ93.ui String.ui List.ui BasicIO.ui TextIO.ui 
-Word8.ui: Word.ui StringCvt.ui 
-Polygdbm.uo: Polygdbm.ui List.ui Gdbm.ui 
-Intset.uo: Intset.ui List.ui 
-CharVector.uo: CharVector.ui String.ui Word8Vector.ui Char.ui 
-Rbset.uo: Rbset.ui List.ui Int.ui 
-Array2.ui: Vector.ui 
-ArraySlice.ui: Vector.ui Array.ui VectorSlice.ui 
-Int.uo: Int.ui String.ui StringCvt.ui Char.ui 
-Signal.ui: Word.ui 
-Buffer.uo: Buffer.ui String.ui Substring.ui 
-PackRealBig.ui: Word8Array.ui Word8Vector.ui 
-Dynlib.uo: Dynlib.ui 
-Dynarray.uo: Dynarray.ui Array.ui 
-Word8Vector.ui: Word8.ui 
-PP.uo: PP.ui String.ui List.ui Vector.ui Array.ui TextIO.ui 
+    Lexing.ui
+String.uo: String.ui List.ui Strbase.ui Char.ui
+NJ93.uo: NJ93.ui String.ui List.ui BasicIO.ui TextIO.ui
+Word8.ui: Word.ui StringCvt.ui
+Polygdbm.uo: Polygdbm.ui List.ui Gdbm.ui
+Intset.uo: Intset.ui List.ui
+CharVector.uo: CharVector.ui String.ui Word8Vector.ui Char.ui
+Rbset.uo: Rbset.ui List.ui Int.ui
+Array2.ui: Vector.ui
+ArraySlice.ui: Vector.ui Array.ui VectorSlice.ui
+Int.uo: Int.ui String.ui StringCvt.ui Char.ui
+Signal.ui: Word.ui
+Buffer.uo: Buffer.ui String.ui Substring.ui
+PackRealBig.ui: Word8Array.ui Word8Vector.ui
+Dynlib.uo: Dynlib.ui
+Dynarray.uo: Dynarray.ui Array.ui
+Word8Vector.ui: Word8.ui
+PP.uo: PP.ui String.ui List.ui Vector.ui Array.ui TextIO.ui
 Word8ArraySlice.ui: Word8Array.ui Word8.ui Word8Vector.ui \
-    Word8VectorSlice.ui 
-Parsing.uo: Parsing.ui Lexing.ui Vector.ui Obj.uo 
+    Word8VectorSlice.ui
+Parsing.uo: Parsing.ui Lexing.ui Vector.ui Obj.uo
 Socket.uo: Socket.ui Word.ui Dynlib.ui Word8Array.ui Vector.ui \
-    Word8Vector.ui Time.ui Word8VectorSlice.ui 
+    Word8Vector.ui Time.ui Word8VectorSlice.ui
 Mysql.uo: Mysql.ui String.ui Real.ui Dynlib.ui StringCvt.ui Msp.ui List.ui \
-    Date.ui Option.ui Word8Array.ui Vector.ui Substring.ui Int.ui 
+    Date.ui Option.ui Word8Array.ui Vector.ui Substring.ui Int.ui
 Help.uo: Help.ui String.ui StringCvt.ui List.ui BasicIO.ui Vector.ui \
-    TextIO.ui Char.ui 
+    TextIO.ui Char.ui
 Date.uo: Date.ui String.ui Real.ui StringCvt.ui Option.ui Vector.ui Int.ui \
-    Time.ui Char.ui 
-Random.uo: Random.ui 
-Math.uo: Math.ui 
-Binaryset.uo: Binaryset.ui List.ui 
+    Time.ui Char.ui
+Random.uo: Random.ui
+Math.uo: Math.ui
+Binaryset.uo: Binaryset.ui List.ui
 Byte.uo: Byte.ui String.ui Word8.ui Word8ArraySlice.ui Substring.ui \
-    Word8Vector.ui Char.ui Word8VectorSlice.ui 
-Weak.uo: Weak.ui 
-Timer.uo: Timer.ui Time.ui 
-BasicIO.uo: BasicIO.ui 
+    Word8Vector.ui Char.ui Word8VectorSlice.ui
+Weak.uo: Weak.ui
+Timer.uo: Timer.ui Time.ui
+BasicIO.uo: BasicIO.ui
 Unix.uo: Unix.ui BinIO.ui Signal.ui Word.ui Dynlib.ui Option.ui Vector.ui \
-    OS.ui TextIO.ui Obj.uo 
-Listsort.uo: Listsort.ui List.ui 
-Process.uo: Process.ui List.ui BasicIO.ui Time.ui 
-Susp.uo: Susp.ui 
+    OS.ui TextIO.ui Obj.uo
+Listsort.uo: Listsort.ui List.ui
+Process.uo: Process.ui List.ui BasicIO.ui Time.ui
+Susp.uo: Susp.ui
 CharArraySlice.uo: CharArraySlice.ui CharVector.ui CharArray.ui \
-    Word8ArraySlice.ui CharVectorSlice.ui 
-Arraysort.uo: Arraysort.ui Array.ui 
-Callback.uo: Callback.ui Polyhash.ui 
-Mosml.ui: Word8Vector.ui 
-Lexing.ui: CharArray.ui Obj.uo 
-Word.uo: Word.ui String.ui StringCvt.ui Char.ui 
-CharArray.ui: CharVector.ui Char.ui 
-Nonstdio.uo: Nonstdio.ui BasicIO.ui CharArray.ui 
+    Word8ArraySlice.ui CharVectorSlice.ui
+Arraysort.uo: Arraysort.ui Array.ui
+Callback.uo: Callback.ui Polyhash.ui
+Mosml.ui: Word8Vector.ui
+Lexing.ui: CharArray.ui Obj.uo
+Word.uo: Word.ui String.ui StringCvt.ui Char.ui
+CharArray.ui: CharVector.ui Char.ui
+Nonstdio.uo: Nonstdio.ui BasicIO.ui CharArray.ui
 Misc.uo: Misc.ui String.ui List.ui Option.ui Vector.ui Array.ui TextIO.ui \
-    Char.ui 
-Mosmlcookie.ui: Date.ui 
-FileSys.ui: Time.ui 
-Bool.ui: StringCvt.ui 
-Word8Array.ui: Word8.ui Word8Vector.ui 
-Strbase.uo: Strbase.ui List.ui 
-Splayset.uo: Splayset.ui List.ui Splaytree.ui 
-Polyhash.uo: Polyhash.ui Array.ui 
+    Char.ui
+Mosmlcookie.ui: Date.ui
+FileSys.ui: Time.ui
+Bool.ui: StringCvt.ui
+Word8Array.ui: Word8.ui Word8Vector.ui
+Strbase.uo: Strbase.ui List.ui
+Splayset.uo: Splayset.ui List.ui Splaytree.ui
+Polyhash.uo: Polyhash.ui Array.ui
 CharVectorSlice.uo: CharVectorSlice.ui CharVector.ui Substring.ui Char.ui \
-    Word8VectorSlice.ui 
-VectorSlice.uo: VectorSlice.ui Vector.ui 
-Time.ui: StringCvt.ui 
-Char.uo: Char.ui Strbase.ui 
-TextIO.uo: TextIO.ui String.ui Char.ui 
-OS.uo: OS.ui 
-PackRealLittle.ui: Word8Array.ui Word8Vector.ui 
+    Word8VectorSlice.ui
+VectorSlice.uo: VectorSlice.ui Vector.ui
+Time.ui: StringCvt.ui
+Char.uo: Char.ui Strbase.ui
+TextIO.uo: TextIO.ui String.ui Char.ui
+OS.uo: OS.ui
+PackRealLittle.ui: Word8Array.ui Word8Vector.ui

--- a/src/mosmllib/test/Makefile
+++ b/src/mosmllib/test/Makefile
@@ -18,7 +18,7 @@ libtest: links noinput.pipe
 	exec 4<> noinput.pipe	&& mosml -I .. -P full test.sml > result 2>&1
 #	diff result result.ok
 
-# with the current compiler and the current library 
+# with the current compiler and the current library
 newtest: links noinput.pipe
 	exec 4<> noinput.pipe	&& ../../camlrunm ../../compiler/mosmltop -stdlib .. -P full test.sml > result 2>&1
 #	diff result result.ok
@@ -27,8 +27,8 @@ newtest: links noinput.pipe
 current:
 	$(MAKE) newtest
 
-cmdline: 
-	mosmlc -o cmdline cmdline.sml 
+cmdline:
+	mosmlc -o cmdline cmdline.sml
 	cmdline arg1 arg2 arg3
 
 noinput.pipe:
@@ -43,12 +43,12 @@ links:
 	ln -sf testcycl testcycl
 
 clean:
-	rm -f result 
+	rm -f result
 	rm -f cmdline cmdline.ui cmdline.uo
-	rm -f empty.dat medium.dat  small1.dat  small2.dat  text.dat 
+	rm -f empty.dat medium.dat  small1.dat  small2.dat  text.dat
 	rm -f mosmltestrun
 	rm -f hardlinkA hardlinkB
 	rm -f testlink testcycl testbadl
 	rm -f testrun.ui testrun.uo
 	rm -f noinput.pipe
-	cd callback; make clean
+	cd callback; $(MAKE) clean

--- a/src/mosmlpm/Makefile
+++ b/src/mosmlpm/Makefile
@@ -21,7 +21,7 @@ all: mosmlpm
 
 mosmlpm: $(STRFILES) $(TOPFILES)
 	$(MOSMLC) $(COMPFLAGS) -structure $(STRFILES) -toplevel $(TOPFILES)
-	$(MOSMLL) $(LINKFLAGS) -noheader $(OBJS) -o mosmlpm 
+	$(MOSMLL) $(LINKFLAGS) -noheader $(OBJS) -o mosmlpm
 
 clean:
 	rm -f *.ui
@@ -30,7 +30,7 @@ clean:
 	rm -f test/*.uo
 	rm -f mosmlpm
 	rm -f Makefile.bak
-#	cd test; make clean
+#	cd test; $(make) clean
 
 install:
 	${INSTALL_DATA} mosmlpm $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
- Update all the makefiles to reference $(MAKE) in case you invoked the build with `gmake` (as on OpenBSD)
- Prefer `cc` on OpenBSD, and update the mosmlc.tpl parameterize CC
- Support PREFIX=/path/ make world install
- Remove warnings from sizes.c test with %ld instead of %d.
- Ensure $cc is used instead of hardcoded gcc in autoconf

With this, I'm able to `gmake world` and install on the latest OpenBSD. I can test this, also on Linux, but I don't have access to other machine types at the moment to ensure I didn't break anything.