### PR TITLE
fix loop in autoconf volatile

### DIFF
--- a/src/config/auto-aux/align.c
+++ b/src/config/auto-aux/align.c
@@ -95,7 +95,7 @@ int speedtest(p)
   return total;
 }
 
-main()
+int main(int argc, char ** argv)
 {
   long n[1001];
   int speed_aligned, speed_unaligned;

--- a/src/config/auto-aux/bytecopy.c
+++ b/src/config/auto-aux/bytecopy.c
@@ -8,7 +8,7 @@ char buffer[27];
 #define cpy copy
 #endif
 
-main()
+int main(int argc, char ** argv)
 {
   cpy("abcdefghijklmnopqrstuvwxyz", buffer, 27);
   if (strcmp(buffer, "abcdefghijklmnopqrstuvwxyz") != 0) exit(1);

--- a/src/config/auto-aux/dblalign.c
+++ b/src/config/auto-aux/dblalign.c
@@ -19,7 +19,7 @@ void sig_handler()
   longjmp(failure, 1);
 }
 
-main()
+int main(int argc, char ** argv)
 {
 #define ARRSIZE 100
   long n[ARRSIZE];

--- a/src/config/auto-aux/endian.c
+++ b/src/config/auto-aux/endian.c
@@ -1,9 +1,10 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
-main()
+int main(int argc, char ** argv)
 {
-  long n[2];
+  int32_t n[2];
   char * p;
 
   n[0] = 0x41424344;

--- a/src/config/auto-aux/schar.c
+++ b/src/config/auto-aux/schar.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
 char foo[]="\377";
-main()
+int main(int argc, char ** argv)
 {
   int i;
   i = foo[0];

--- a/src/config/auto-aux/schar2.c
+++ b/src/config/auto-aux/schar2.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
 signed char foo[]="\377";
-main()
+int main(int argc, char ** argv)
 {
   int i;
   i = foo[0];

--- a/src/config/auto-aux/setjmp.c
+++ b/src/config/auto-aux/setjmp.c
@@ -1,6 +1,7 @@
 #include <setjmp.h>
+#include <stdlib.h>
 
-main()
+int main(int argc, char ** argv)
 {
   jmp_buf buf;
   int i;

--- a/src/config/auto-aux/sighandler.c
+++ b/src/config/auto-aux/sighandler.c
@@ -1,8 +1,8 @@
 #include <signal.h>
 
-int main()
+int main(int argc, char ** argv)
 {
-  SIGRETURN (*old)();
+  sig_t old;
   old = signal(SIGQUIT, SIG_DFL);
   return 0;
 }

--- a/src/config/auto-aux/signals.c
+++ b/src/config/auto-aux/signals.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <signal.h>
+#include <unistd.h>
 
 int counter;
 

--- a/src/config/autoconf
+++ b/src/config/autoconf
@@ -84,7 +84,8 @@ while true; do
   case $? in
   100) echo "Your compiler chokes on the \"volatile\" modifier."
        echo "Never mind, we'll do without it."
-       volatile="-Dvolatile=";;
+       volatile="-Dvolatile="
+       break;;
     0) echo "This architecture has no alignment constraints."
        echo "#undef ALIGNMENT" >> m.h
        break;;

--- a/src/config/autoconf
+++ b/src/config/autoconf
@@ -84,8 +84,7 @@ while true; do
   case $? in
   100) echo "Your compiler chokes on the \"volatile\" modifier."
        echo "Never mind, we'll do without it."
-       volatile="-Dvolatile="
-       break;;
+       volatile="-Dvolatile=";;
     0) echo "This architecture has no alignment constraints."
        echo "#undef ALIGNMENT" >> m.h
        break;;


### PR DESCRIPTION
In recent macOS, when trying to autoconf, will show up the message and keep looping:
```
Your compiler chokes on the "volatile" modifier.
Never mind, we'll do without it.
```

But actually it's because clang will trigger errors like:
```
dblalign.c:22:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   22 | main()
```
so i try to update the `main` function type spec.